### PR TITLE
cleanup of Embargo, Tombstone and Request Copy.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -310,6 +310,23 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport {
         return matchingBundles;
     }
 
+    // Pass ORIGINAL for NAME
+    public List<String> getFiles(String name) {
+        List<String> matchingBitstreams = new ArrayList<>();
+         // now only keep bundles with matching names
+        List<Bundle> bunds = getBundles();
+        for (Bundle bundle : bunds) {
+            if (name.equals(bundle.getName())) {
+                List<Bitstream> bits = bundle.getBitstreams();
+                for (Bitstream bit : bits) {
+                    matchingBitstreams.add(bit.getName());
+                }   
+            }
+        }
+        return matchingBitstreams;
+    }
+
+
     /**
      * Add a bundle to the item, should not be made public since we don't want to skip business logic
      *

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -652,6 +652,15 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         addMetadata(context, item, MetadataSchemaEnum.DC.getName(), "description", "withdrawalreason", "en", reason);
 
+        // To store the filename for display later.
+        clearMetadata(context, item, "dc", "description", "filename", Item.ANY);
+
+        // Find out the item's bitnames
+        List<String> bitnames = item.getFiles("ORIGINAL");
+        for (String bitname : bitnames) {
+            addMetadata(context, item, MetadataSchemaEnum.DC.getName(), "description", "filename", "en", bitname);
+        } 
+
         // Update item in DB
         update(context, item);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BundleBitstreamLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BundleBitstreamLinkRepository.java
@@ -39,6 +39,9 @@ public class BundleBitstreamLinkRepository extends AbstractDSpaceRestRepository
     @Autowired
     BundleService bundleService;
 
+    // UM - this is suppose to not send bitstreams unless the bundle has READ
+    //      access.  I spoke to Tim about it and he highly recommended NOT 
+    //      changing this.
     @PreAuthorize("hasPermission(#bundleId, 'BUNDLE', 'READ')")
     public Page<BitstreamRest> getBitstreams(@Nullable HttpServletRequest request,
                                              UUID bundleId,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemStepLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemStepLinkRepository.java
@@ -65,7 +65,11 @@ public class WorkflowItemStepLinkRepository extends AbstractDSpaceRestRepository
         try {
             XmlWorkflowItem xmlWorkflowItem = xmlWorkflowItemService.find(context, workflowItemId);
             if (xmlWorkflowItem == null) {
-                throw new ResourceNotFoundException("XmlWorkflowItem with id: " + workflowItemId + " wasn't found");
+                // UM Change - During submission, if an item is embargoed, we endup here. 
+                // and are stuck in the submission page, this command will return the user
+                // to the MyDSpace page.
+                return converter.toRest( xmlWorkflowFactory.getStepByName("finaleditstep"), projection);
+                //throw new ResourceNotFoundException("XmlWorkflowItem with id: " + workflowItemId + " wasn't found");
             }
             List<PoolTask> poolTasks = poolTaskService.find(context, xmlWorkflowItem);
             List<ClaimedTask> claimedTasks = claimedTaskService.find(context, xmlWorkflowItem);

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -151,14 +151,14 @@ db.removeabandonedtimeout = 300
 ##### Email settings ######
 
 # SMTP mail server (allows DSpace to send email notifications)
-mail.server = smtp.example.com
+mail.server = 
 
 # SMTP mail server authentication username and password (if required)
-mail.server.username = jb5852601@gmail.com
-mail.server.password =  
+mail.server.username = 
+mail.server.password = 
 
 # SMTP mail server alternate port (defaults to 25)
-mail.server.port = 465
+mail.server.port = 
 
 # From address for mail
 # All mail from the DSpace site will use this 'from' address
@@ -861,6 +861,13 @@ checker.retention.default=10y
 checker.retention.CHECKSUM_MATCH=8w
 
 
+#### Peer Reviewed Collection ######
+#out of box
+#pr.collectionid = a0042b17-4c5b-4aa3-a1d8-2451bb2ab02e
+#dev 30 from 5.1 code
+pr.collectionid = 2875765d-9ad6-4378-b295-d6d329f9b538
+
+
 ### Item export and download settings ###
 # The directory where the exports will be done and compressed
 org.dspace.app.itemexport.work.dir = ${dspace.dir}/exports
@@ -1536,6 +1543,12 @@ log.report.dir = ${dspace.dir}/log
 # For example , this is required to track downloads of bitstreams. This setting is only used by Google Analytics 4.
 # For more details see https://developers.google.com/analytics/devguides/collection/protocol/ga4
 # google.analytics.api-secret = 
+
+# Should a rejection of a copy request send an email back to the requester?
+# Defaults to "true", which means a rejection email is sent back.
+# Setting it to "false" results in a silent rejection.
+request.item.reject.email = true
+
 
 ####################################################################
 #---------------------------------------------------------------#


### PR DESCRIPTION
DONE The patch to make request copy work.
	modified:   dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java

DONE... to get the filenames of files in original bundle.
	modified:   dspace-api/src/main/java/org/dspace/content/Item.java

DONE... store filename in the metadata when item is withdrawn.
	modified:   dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java

DONE....comment about how bitstreams are delivered.
	modified:   dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BundleBitstreamLinkRepository.java

DONE....   This one is to get out of being stuck in deposit when doing an embargo at deposit.
	modified:   dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemStepLinkRepository.java

DONE... Patch for request copy
       modified:  dspace/config/dspace.cfg